### PR TITLE
Browser Router Fix.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -215,7 +215,7 @@ function App() {
     <div className="App">
       <Routes>
         <Route
-          path="/mdleaguedata"
+          path="/"
           element={
             <>
               <div className="App-header">

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import reportWebVitals from './reportWebVitals';
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename='/mdleaguedata'>
       <App />
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
Added `basename = "/mdleaguedata"` to BrowserRouter to account for GH Pages hosting behavior. 